### PR TITLE
Adds support for check mode

### DIFF
--- a/tasks/check.yml
+++ b/tasks/check.yml
@@ -5,6 +5,7 @@
   changed_when: false
   ignore_errors: true
   register: consul_installed_version
+  check_mode: no
 
 - name: Consul | Set consul_installed_version fact
   set_fact:


### PR DESCRIPTION
Failed when running `--check` on the playbook.

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Adds support for the `--check` flag when running the playbook

### Benefits

You may want to run a check before the full playbook

### Possible Drawbacks

None that I know of.

### Applicable Issues

Current state does not allow the check flag.
